### PR TITLE
header level is an integer not a string

### DIFF
--- a/bin/wetzel.js
+++ b/bin/wetzel.js
@@ -74,7 +74,7 @@ var options = {
     searchPath: searchPath,
     styleMode: styleModeArgument,
     writeTOC: !defaultValue(defaultValue(argv.n, argv.noTOC), false),
-    headerLevel: defaultValue(defaultValue(argv.l, argv.headerLevel), 1),
+    headerLevel: parseInt(defaultValue(defaultValue(argv.l, argv.headerLevel), 1)),
     checkmark: defaultValue(defaultValue(argv.c, argv.checkmark), null),
     mustKeyword: defaultValue(defaultValue(argv.k, argv.keyword), null),
     schemaRelativeBasePath: defaultValue(defaultValue(argv.p, argv.schemaPath), null),


### PR DESCRIPTION
The header levels command-line argument was not correctly parsed from the command line, resulting in incorrect header levels in the code generation (for example headerLevel + 1 was interpreted as string concatenation, resulting in header level of "21" instead of 3). This small PR fixes it.